### PR TITLE
Play handlers key fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ in  [ Ansible.Play::{
 - hosts: localhost
   tasks:
     - debug:
-        msg: "Hello world"
+        msg: Hello world
     - become: true
-      name: "Installing package"
+      name: Installing package
       package:
         name: emacs-nox
         state: present

--- a/defaults/play.dhall
+++ b/defaults/play.dhall
@@ -7,7 +7,7 @@
 , gather_facts = None Bool
 , gather_subset = None (List Text)
 , gather_timeout = None Natural
-, handlers = None (List Text)
+, handlers = None (List ../types/task.dhall)
 , max_fail_percentage = None Double
 , order = None Text
 , post_tasks = None (List ../types/task.dhall)

--- a/defaults/task.dhall
+++ b/defaults/task.dhall
@@ -54,6 +54,7 @@
 , include_vars = None ../types/modules/include_vars.dhall
 , iptables = None ../types/modules/iptables.dhall
 , lineinfile = None ../types/modules/lineinfile.dhall
+, listen = None Text
 , loop = None Text
 , loop_control = None ../types/loop_control.dhall
 , mount = None ../types/modules/mount.dhall

--- a/package.dhall
+++ b/package.dhall
@@ -115,7 +115,7 @@
 , Pip =
     ./schemas/modules/pip.dhall sha256:51b3cc676edd303581ff5fdc876839c26454b9dbc16c1083af3e419cab4ea960
 , Play =
-    ./schemas/play.dhall sha256:819639085e2595beea3378127a0477de1de8b693c4eb73f7a8895813d6d1e9d7
+    ./schemas/play.dhall sha256:2ecf45c458f974c9ab99d445d52966afe3b7286fa527c7d37a6e229fcd3e9691
 , RpmKey =
     ./schemas/modules/rpm_key.dhall sha256:dbba053f922e9bd0c8eed500c6dcf4cea6299f6b80a4123296ffffbd51129ef9
 , S3Bucket =
@@ -143,7 +143,7 @@
 , Systemd =
     ./schemas/modules/systemd.dhall sha256:0a4a9c4de96d1fe4dfaef759972fef703b9307998611f956ece460fbf6d6b561
 , Task =
-    ./schemas/task.dhall sha256:050f59d3f4bb4621ef298584f2b091f1d31d7f2f92a2a54e3223458c69ea2a2b
+    ./schemas/task.dhall sha256:dd6f30546bdbeab486d7714ae4b513bed3a9680842864d93aa7eabeed85f8b63
 , Template =
     ./schemas/modules/template.dhall sha256:000cf1bd44cc9db2ee63ab938f192d864f5ef6257977aace93da94f861d1951d
 , Unarchive =

--- a/types/play.dhall
+++ b/types/play.dhall
@@ -7,7 +7,7 @@
 , vars_files : Optional (List Text)
 , vars_prompt : Optional (List Text)
 , roles : Optional (List Text)
-, handlers : Optional (List Text)
+, handlers : Optional (List ./task.dhall)
 , pre_tasks : Optional (List ./task.dhall)
 , post_tasks : Optional (List ./task.dhall)
 , tasks : Optional (List ./task.dhall)

--- a/types/task.dhall
+++ b/types/task.dhall
@@ -14,6 +14,7 @@
 , become_user : Optional Text
 , become_flags : Optional Text
 , notify : Optional (List Text)
+, listen : Optional Text
 , poll : Optional Natural
 , retries : Optional Natural
 , until : Optional Text


### PR DESCRIPTION
The type of the `handlers` field on plays was `Optional (List Text)` but this key is supposed to contain an array of tasks ([documentation here][1]).  When a task is used as a handler, it can have a `listen` key set to a topic string, so I added the `listen` key to the task type.

@TristanCacqueray since you confirmed that the quoting in the example in `README.md` is due to an old version of `dhall-to-yaml`, I went ahead and checked in the updated `README.md`

[1]: https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html#handlers-running-operations-on-change